### PR TITLE
feat: Display website favicons next to bookmark names

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -42,7 +42,20 @@ function renderBookmarks(bookmarks, container, depth = 0) {
     } else if (bookmark.url) {
       const el = document.createElement('div');
       el.className = 'bookmark';
-      el.innerHTML = `<a href="${bookmark.url}" target="_blank">${bookmark.title}</a>`;
+
+      const link = document.createElement('a');
+      link.href = bookmark.url;
+      link.target = '_blank';
+
+      const img = document.createElement('img');
+      img.src = 'chrome://favicon/size/16@1x/' + bookmark.url;
+      img.alt = 'Favicon';
+      img.className = 'favicon-img'; // Added class for styling
+
+      link.appendChild(img);
+      link.appendChild(document.createTextNode(bookmark.title));
+
+      el.appendChild(link);
       container.appendChild(el);
     }
   });

--- a/style.css
+++ b/style.css
@@ -59,3 +59,10 @@ body {
 .folder.expanded h3 .arrow {
   transform: rotate(0deg); /* 🔽 Triángulo hacia abajo */
 }
+
+.favicon-img {
+  width: 16px;
+  height: 16px;
+  margin-right: 5px;
+  vertical-align: middle;
+}


### PR DESCRIPTION
Modifies the bookmark rendering logic in `popup.js` to include an `<img>` tag for each bookmark. The `src` of this image is set to `chrome://favicon/size/16@1x/<bookmark_url>` to fetch the site's favicon.

Adds corresponding CSS rules in `style.css` to ensure favicons are displayed at a consistent size (16x16px), vertically aligned with the bookmark title, and have a small right margin.

This enhances your experience by providing a visual cue for each bookmark, making it easier to identify bookmarks at a glance.